### PR TITLE
toggle chat

### DIFF
--- a/front/app/main/@main/game/page.tsx
+++ b/front/app/main/@main/game/page.tsx
@@ -2,18 +2,38 @@ import { GameChipProfile } from "@/components/Game/GameUserProfile";
 import CharacterSelector from "@/components/Game/GameCharacterSelector";
 import GameStartButton from "@/components/Game/GameStartButton";
 import { ChatDialog } from "@/components/Chat/ChatDialog";
+import { IconChatAlternative } from "@/components/ImageLibrary";
 
 export default function GamePage() {
     return (
-        <main className="relative flex h-full flex-col items-center justify-end gap-2.5 self-stretch p-2.5">
-            <div className="flex flex-col items-center justify-center ">
+        <div className="relative flex h-full flex-col items-center justify-start gap-2.5 overflow-auto rounded-lg p-6 backdrop-blur-3xl">
+            <div className="flex h-full flex-row items-center justify-center rounded-lg bg-windowGlass/30 ">
+                <div className="relative flex h-full flex-col items-center">
+                    <input
+                        type="checkbox"
+                        id="chatBox"
+                        className="peer hidden"
+                    />
+                    <label className="relative" htmlFor="chatBox">
+                        <IconChatAlternative
+                            width={64}
+                            height={64}
+                            className="p-4"
+                        />
+                    </label>
+                    <ChatDialog
+                        outerFrame="w-0 overflow-clip peer-checked:w-fit rounded-[32px] min-h-[200px]"
+                        innerFrame="max-w-[600px]"
+                    />
+                </div>
+
                 <div className="flex flex-col items-center justify-between self-stretch px-2.5 py-[30px]">
                     {/* name tag */}
-                    <div className="gameNameTag flex items-center gap-[250px] rounded-[50px] px-[106px] py-10 shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]">
-                        <div className="flex flex-col justify-center text-center text-2xl font-bold italic leading-[normal] text-white">
+                    <div className="gameNameTag flex w-full max-w-xl justify-around rounded-full py-2">
+                        <div className="flex w-12 flex-col justify-center text-center text-2xl font-bold italic leading-[normal] text-white">
                             TEAM PURPLE
                         </div>
-                        <div className="flex justify-center text-center text-2xl font-bold italic leading-[normal] text-white">
+                        <div className="flex w-12 justify-center text-center text-2xl font-bold italic leading-[normal] text-white">
                             TEAM CHERRY
                         </div>
                     </div>
@@ -32,10 +52,6 @@ export default function GamePage() {
                     {/* game main bar - for operation */}
                     <div className="relative flex flex-col items-center justify-center gap-10 self-stretch lg:flex-row">
                         {/* TODO: selectable chatting room / if selected, shurink other one (chat / character select)*/}
-                        <ChatDialog
-                            outerFrame="rounded-[32px] min-h-[200px]"
-                            innerFrame="max-w-[600px]"
-                        />
                         <CharacterSelector />
                         <GameStartButton />
                     </div>

--- a/front/app/main/@main/game/page.tsx
+++ b/front/app/main/@main/game/page.tsx
@@ -57,6 +57,6 @@ export default function GamePage() {
                     </div>
                 </div>
             </div>
-        </main>
+        </div>
     );
 }


### PR DESCRIPTION
게임페이지의 레이아웃을 최대한 모바일에서도 똑같은 느낌을 주려면 chat자체가 너무 큰 것 같아서, 대화창을 토글 가능하게 만들었습니다. 장래적으로는 채팅화면처럼 큰 화면에서는 사이드바, 작은 화면에서는 덮어씌워지는 무언가(뭐라고 하는지 모르겠네요)로 바꿔서 왔다갔다 할 수 있게 하면 좋을 것 같고, 또는 챗 화면 게임화면을 아래쪽 탭에 만들어서 이동할 수 있게 만들어도 좋을 것 같습니다. 


빨리 게임 화면 만들고싶네요!! 