### PR TITLE
Prettier linter config

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": [
+        "next/core-web-vitals",
+        "prettier"
+    ]
+}

--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -9,8 +9,8 @@
     ],
     "extends": [
         "eslint:recommended",
-        "next/core-web-vitals",
         "plugin:@typescript-eslint/recommended",
+        "next/core-web-vitals",
         "prettier"
     ],
     "rules": {

--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -1,6 +1,18 @@
 {
+    "env": {
+        "browser": true,
+        "es2021": true,
+        "node": true
+    },
+    "plugins": [
+        "@typescript-eslint"
+    ],
     "extends": [
+        "eslint:recommended",
         "next/core-web-vitals",
+        "plugin:@typescript-eslint/recommended",
         "prettier"
-    ]
+    ],
+    "rules": {
+    }
 }

--- a/front/.eslintrc.yml
+++ b/front/.eslintrc.yml
@@ -1,11 +1,3 @@
 extends:
     - next/core-web-vitals
     - prettier
-
-rules:
-    indent:
-        - error
-        - 4
-    linebreak-style:
-        - error
-        - unix

--- a/front/.eslintrc.yml
+++ b/front/.eslintrc.yml
@@ -1,3 +1,0 @@
-extends:
-    - next/core-web-vitals
-    - prettier

--- a/front/.prettierrc.json
+++ b/front/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+    "plugins": ["prettier-plugin-tailwindcss"],
+    "tabWidth": 4
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,13 +8,12 @@
             "name": "front-end-next",
             "version": "0.1.0",
             "dependencies": {
-                "@types/node": "20.4.5",
-                "@types/react": "18.2.18",
+                "@types/node": "20.5.0",
+                "@types/react": "18.2.20",
                 "@types/react-dom": "18.2.7",
-                "autoprefixer": "10.4.14",
-                "clsx": "^2.0.0",
+                "autoprefixer": "10.4.15",
                 "next": "latest",
-                "postcss": "8.4.26",
+                "postcss": "8.4.27",
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
                 "react-fzf": "^0.1.1",
@@ -23,11 +22,13 @@
             },
             "devDependencies": {
                 "@svgr/webpack": "^8.0.1",
-                "eslint": "8.46.0",
-                "eslint-config-next": "13.4.12",
-                "eslint-config-prettier": "^8.9.0",
-                "prettier": "^3.0.0",
-                "prettier-plugin-tailwindcss": "^0.4.1"
+                "@typescript-eslint/eslint-plugin": "^6.4.0",
+                "@typescript-eslint/parser": "^6.4.0",
+                "eslint": "8.47.0",
+                "eslint-config-next": "13.4.16",
+                "eslint-config-prettier": "^9.0.0",
+                "prettier": "^3.0.1",
+                "prettier-plugin-tailwindcss": "^0.5.2"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -2074,9 +2075,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
-            "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+            "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -2097,9 +2098,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.46.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
-            "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
+            "version": "8.47.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
+            "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2187,23 +2188,23 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "node_modules/@next/env": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.10.tgz",
-            "integrity": "sha512-3G1yD/XKTSLdihyDSa8JEsaWOELY+OWe08o0LUYzfuHp1zHDA8SObQlzKt+v+wrkkPcnPweoLH1ImZeUa0A1NQ=="
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.16.tgz",
+            "integrity": "sha512-pCU0sJBqdfKP9mwDadxvZd+eLz3fZrTlmmDHY12Hdpl3DD0vy8ou5HWKVfG0zZS6tqhL4wnQqRbspdY5nqa7MA=="
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "13.4.12",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.12.tgz",
-            "integrity": "sha512-6rhK9CdxEgj/j1qvXIyLTWEaeFv7zOK8yJMulz3Owel0uek0U9MJCGzmKgYxM3aAUBo3gKeywCZKyQnJKto60A==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.16.tgz",
+            "integrity": "sha512-QuFtQl+oSEEQb0HMYBdvBoUaTiMxbY3go/MFkF3zOnfY0t84+IbAX78cw8ZCfr6cA6UcTq3nMIlCrHwDC/moxg==",
             "dev": true,
             "dependencies": {
                 "glob": "7.1.7"
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.10.tgz",
-            "integrity": "sha512-4bsdfKmmg7mgFGph0UorD1xWfZ5jZEw4kKRHYEeTK9bT1QnMbPVPlVXQRIiFPrhoDQnZUoa6duuPUJIEGLV1Jg==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.16.tgz",
+            "integrity": "sha512-Rl6i1uUq0ciRa3VfEpw6GnWAJTSKo9oM2OrkGXPsm7rMxdd2FR5NkKc0C9xzFCI4+QtmBviWBdF2m3ur3Nqstw==",
             "cpu": [
                 "arm64"
             ],
@@ -2216,9 +2217,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.10.tgz",
-            "integrity": "sha512-ngXhUBbcZIWZWqNbQSNxQrB9T1V+wgfCzAor2olYuo/YpaL6mUYNUEgeBMhr8qwV0ARSgKaOp35lRvB7EmCRBg==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.16.tgz",
+            "integrity": "sha512-o1vIKYbZORyDmTrPV1hApt9NLyWrS5vr2p5hhLGpOnkBY1cz6DAXjv8Lgan8t6X87+83F0EUDlu7klN8ieZ06A==",
             "cpu": [
                 "x64"
             ],
@@ -2231,9 +2232,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.10.tgz",
-            "integrity": "sha512-SjCZZCOmHD4uyM75MVArSAmF5Y+IJSGroPRj2v9/jnBT36SYFTORN8Ag/lhw81W9EeexKY/CUg2e9mdebZOwsg==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.16.tgz",
+            "integrity": "sha512-JRyAl8lCfyTng4zoOmE6hNI2f1MFUr7JyTYCHl1RxX42H4a5LMwJhDVQ7a9tmDZ/yj+0hpBn+Aan+d6lA3v0UQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2246,9 +2247,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.10.tgz",
-            "integrity": "sha512-F+VlcWijX5qteoYIOxNiBbNE8ruaWuRlcYyIRK10CugqI/BIeCDzEDyrHIHY8AWwbkTwe6GRHabMdE688Rqq4Q==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.16.tgz",
+            "integrity": "sha512-9gqVqNzUMWbUDgDiND18xoUqhwSm2gmksqXgCU0qaOKt6oAjWz8cWYjgpPVD0WICKFylEY/gvPEP1fMZDVFZ/g==",
             "cpu": [
                 "arm64"
             ],
@@ -2261,9 +2262,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.10.tgz",
-            "integrity": "sha512-WDv1YtAV07nhfy3i1visr5p/tjiH6CeXp4wX78lzP1jI07t4PnHHG1WEDFOduXh3WT4hG6yN82EQBQHDi7hBrQ==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.16.tgz",
+            "integrity": "sha512-KcQGwchAKmZVPa8i5PLTxvTs1/rcFnSltfpTm803Tr/BtBV3AxCkHLfhtoyVtVzx/kl/oue8oS+DSmbepQKwhw==",
             "cpu": [
                 "x64"
             ],
@@ -2276,9 +2277,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.10.tgz",
-            "integrity": "sha512-zFkzqc737xr6qoBgDa3AwC7jPQzGLjDlkNmt/ljvQJ/Veri5ECdHjZCUuiTUfVjshNIIpki6FuP0RaQYK9iCRg==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.16.tgz",
+            "integrity": "sha512-2RbMZNxYnJmW8EPHVBsGZPq5zqWAyBOc/YFxq/jIQ/Yn3RMFZ1dZVCjtIcsiaKmgh7mjA/W0ApbumutHNxRqqQ==",
             "cpu": [
                 "x64"
             ],
@@ -2291,9 +2292,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.10.tgz",
-            "integrity": "sha512-IboRS8IWz5mWfnjAdCekkl8s0B7ijpWeDwK2O8CdgZkoCDY0ZQHBSGiJ2KViAG6+BJVfLvcP+a2fh6cdyBr9QQ==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.16.tgz",
+            "integrity": "sha512-thDcGonELN7edUKzjzlHrdoKkm7y8IAdItQpRvvMxNUXa4d9r0ElofhTZj5emR7AiXft17hpen+QAkcWpqG7Jg==",
             "cpu": [
                 "arm64"
             ],
@@ -2306,9 +2307,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.10.tgz",
-            "integrity": "sha512-bSA+4j8jY4EEiwD/M2bol4uVEu1lBlgsGdvM+mmBm/BbqofNBfaZ2qwSbwE2OwbAmzNdVJRFRXQZ0dkjopTRaQ==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.16.tgz",
+            "integrity": "sha512-f7SE1Mo4JAchUWl0LQsbtySR9xCa+x55C0taetjUApKtcLR3AgAjASrrP+oE1inmLmw573qRnE1eZN8YJfEBQw==",
             "cpu": [
                 "ia32"
             ],
@@ -2321,9 +2322,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.10.tgz",
-            "integrity": "sha512-g2+tU63yTWmcVQKDGY0MV1PjjqgZtwM4rB1oVVi/v0brdZAcrcTV+04agKzWtvWroyFz6IqtT0MoZJA7PNyLVw==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.16.tgz",
+            "integrity": "sha512-WamDZm1M/OEM4QLce3lOmD1XdLEl37zYZwlmOLhmF7qYJ2G6oYm9+ejZVv+LakQIsIuXhSpVlOvrxIAHqwRkPQ==",
             "cpu": [
                 "x64"
             ],
@@ -2667,6 +2668,12 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.12",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+            "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+            "dev": true
+        },
         "node_modules/@types/json5": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2674,9 +2681,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.4.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-            "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
+            "version": "20.5.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
+            "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q=="
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.5",
@@ -2684,9 +2691,9 @@
             "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
         },
         "node_modules/@types/react": {
-            "version": "18.2.18",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.18.tgz",
-            "integrity": "sha512-da4NTSeBv/P34xoZPhtcLkmZuJ+oYaCxHmyHzwaDQo9RQPBeXV+06gEk2FpqEcsX9XrnNLvRpVh6bdavDSjtiQ==",
+            "version": "18.2.20",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.20.tgz",
+            "integrity": "sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -2706,26 +2713,68 @@
             "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
             "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
         },
-        "node_modules/@typescript-eslint/parser": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-            "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+        "node_modules/@types/semver": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+            "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+            "dev": true
+        },
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
+            "integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.62.0",
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/typescript-estree": "5.62.0",
-                "debug": "^4.3.4"
+                "@eslint-community/regexpp": "^4.5.1",
+                "@typescript-eslint/scope-manager": "6.4.0",
+                "@typescript-eslint/type-utils": "6.4.0",
+                "@typescript-eslint/utils": "6.4.0",
+                "@typescript-eslint/visitor-keys": "6.4.0",
+                "debug": "^4.3.4",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.2.4",
+                "natural-compare": "^1.4.0",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+                "eslint": "^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
+            "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "6.4.0",
+                "@typescript-eslint/types": "6.4.0",
+                "@typescript-eslint/typescript-estree": "6.4.0",
+                "@typescript-eslint/visitor-keys": "6.4.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -2734,29 +2783,56 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-            "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
+            "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/visitor-keys": "5.62.0"
+                "@typescript-eslint/types": "6.4.0",
+                "@typescript-eslint/visitor-keys": "6.4.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
+            "integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "6.4.0",
+                "@typescript-eslint/utils": "6.4.0",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-            "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
+            "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
             "dev": true,
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2764,21 +2840,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-            "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
+            "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/visitor-keys": "5.62.0",
+                "@typescript-eslint/types": "6.4.0",
+                "@typescript-eslint/visitor-keys": "6.4.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2790,17 +2866,42 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-            "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+        "node_modules/@typescript-eslint/utils": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
+            "integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.62.0",
-                "eslint-visitor-keys": "^3.3.0"
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@types/json-schema": "^7.0.12",
+                "@types/semver": "^7.5.0",
+                "@typescript-eslint/scope-manager": "6.4.0",
+                "@typescript-eslint/types": "6.4.0",
+                "@typescript-eslint/typescript-estree": "6.4.0",
+                "semver": "^7.5.4"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
+            "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.4.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3022,9 +3123,9 @@
             "dev": true
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.14",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-            "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+            "version": "10.4.15",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
+            "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3033,11 +3134,15 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "browserslist": "^4.21.5",
-                "caniuse-lite": "^1.0.30001464",
+                "browserslist": "^4.21.10",
+                "caniuse-lite": "^1.0.30001520",
                 "fraction.js": "^4.2.0",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
@@ -3192,9 +3297,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.9",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-            "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+            "version": "4.21.10",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+            "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3210,9 +3315,9 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001503",
-                "electron-to-chromium": "^1.4.431",
-                "node-releases": "^2.0.12",
+                "caniuse-lite": "^1.0.30001517",
+                "electron-to-chromium": "^1.4.477",
+                "node-releases": "^2.0.13",
                 "update-browserslist-db": "^1.0.11"
             },
             "bin": {
@@ -3291,9 +3396,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001517",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-            "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+            "version": "1.0.30001520",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz",
+            "integrity": "sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3366,14 +3471,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
-        },
-        "node_modules/clsx": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-            "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -3756,9 +3853,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.466",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.466.tgz",
-            "integrity": "sha512-TSkRvbXRXD8BwhcGlZXDsbI2lRoP8dvqR7LQnqQNk9KxXBc4tG8O+rTuXgTyIpEdiqSGKEBSqrxdqEntnjNncA=="
+            "version": "1.4.491",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.491.tgz",
+            "integrity": "sha512-ZzPqGKghdVzlQJ+qpfE+r6EB321zed7e5JsvHIlMM4zPFF8okXUkF5Of7h7F3l3cltPL0rG7YVmlp5Qro7RQLA=="
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -3914,15 +4011,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.46.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
-            "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+            "version": "8.47.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
+            "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.1",
-                "@eslint/js": "^8.46.0",
+                "@eslint/eslintrc": "^2.1.2",
+                "@eslint/js": "^8.47.0",
                 "@humanwhocodes/config-array": "^0.11.10",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -3933,7 +4030,7 @@
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.2.2",
-                "eslint-visitor-keys": "^3.4.2",
+                "eslint-visitor-keys": "^3.4.3",
                 "espree": "^9.6.1",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
@@ -3968,14 +4065,14 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "13.4.12",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.12.tgz",
-            "integrity": "sha512-ZF0r5vxKaVazyZH/37Au/XItiG7qUOBw+HaH3PeyXltIMwXorsn6bdrl0Nn9N5v5v9spc+6GM2ryjugbjF6X2g==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.16.tgz",
+            "integrity": "sha512-Of73d/FiaGf0GLCxxTGdh4rW8bRDvsqypylefkshE/uDDpQr8ifVQsD4UiB99rhegks7nJGkYtUnR3dC7kfFlw==",
             "dev": true,
             "dependencies": {
-                "@next/eslint-plugin-next": "13.4.12",
+                "@next/eslint-plugin-next": "13.4.16",
                 "@rushstack/eslint-patch": "^1.1.3",
-                "@typescript-eslint/parser": "^5.42.0",
+                "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
                 "eslint-import-resolver-node": "^0.3.6",
                 "eslint-import-resolver-typescript": "^3.5.2",
                 "eslint-plugin-import": "^2.26.0",
@@ -3994,9 +4091,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
-            "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+            "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
@@ -4302,9 +4399,9 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-            "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4682,9 +4779,9 @@
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         },
         "node_modules/globals": {
-            "version": "13.20.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+            "version": "13.21.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+            "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -5520,11 +5617,11 @@
             "dev": true
         },
         "node_modules/next": {
-            "version": "13.4.10",
-            "resolved": "https://registry.npmjs.org/next/-/next-13.4.10.tgz",
-            "integrity": "sha512-4ep6aKxVTQ7rkUW2fBLhpBr/5oceCuf4KmlUpvG/aXuDTIf9mexNSpabUD6RWPspu6wiJJvozZREhXhueYO36A==",
+            "version": "13.4.16",
+            "resolved": "https://registry.npmjs.org/next/-/next-13.4.16.tgz",
+            "integrity": "sha512-1xaA/5DrfpPu0eV31Iro7JfPeqO8uxQWb1zYNTe+KDKdzqkAGapLcDYHMLNKXKB7lHjZ7LfKUOf9dyuzcibrhA==",
             "dependencies": {
-                "@next/env": "13.4.10",
+                "@next/env": "13.4.16",
                 "@swc/helpers": "0.5.1",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001406",
@@ -5540,28 +5637,24 @@
                 "node": ">=16.8.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "13.4.10",
-                "@next/swc-darwin-x64": "13.4.10",
-                "@next/swc-linux-arm64-gnu": "13.4.10",
-                "@next/swc-linux-arm64-musl": "13.4.10",
-                "@next/swc-linux-x64-gnu": "13.4.10",
-                "@next/swc-linux-x64-musl": "13.4.10",
-                "@next/swc-win32-arm64-msvc": "13.4.10",
-                "@next/swc-win32-ia32-msvc": "13.4.10",
-                "@next/swc-win32-x64-msvc": "13.4.10"
+                "@next/swc-darwin-arm64": "13.4.16",
+                "@next/swc-darwin-x64": "13.4.16",
+                "@next/swc-linux-arm64-gnu": "13.4.16",
+                "@next/swc-linux-arm64-musl": "13.4.16",
+                "@next/swc-linux-x64-gnu": "13.4.16",
+                "@next/swc-linux-x64-musl": "13.4.16",
+                "@next/swc-win32-arm64-msvc": "13.4.16",
+                "@next/swc-win32-ia32-msvc": "13.4.16",
+                "@next/swc-win32-x64-msvc": "13.4.16"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
-                "fibers": ">= 3.1.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "sass": "^1.3.0"
             },
             "peerDependenciesMeta": {
                 "@opentelemetry/api": {
-                    "optional": true
-                },
-                "fibers": {
                     "optional": true
                 },
                 "sass": {
@@ -5966,9 +6059,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.26",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
-            "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
+            "version": "8.4.27",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+            "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6099,9 +6192,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-            "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+            "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -6114,12 +6207,12 @@
             }
         },
         "node_modules/prettier-plugin-tailwindcss": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.4.1.tgz",
-            "integrity": "sha512-hwn2EiJmv8M+AW4YDkbjJ6HlZCTzLyz1QlySn9sMuKV/Px0fjwldlB7tol8GzdgqtkdPtzT3iJ4UzdnYXP25Ag==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.2.tgz",
+            "integrity": "sha512-i4swJk4f8YWK99BRPX3DdDNwMr6U1X8y9rvxGeX5zf090+SsHpPSVjgOb041Hh6/nZJWPi/JYno9UgBDm+/RxA==",
             "dev": true,
             "engines": {
-                "node": ">=12.17.0"
+                "node": ">=14.21.3"
             },
             "peerDependencies": {
                 "@ianvs/prettier-plugin-sort-imports": "*",
@@ -6127,17 +6220,15 @@
                 "@shopify/prettier-plugin-liquid": "*",
                 "@shufo/prettier-plugin-blade": "*",
                 "@trivago/prettier-plugin-sort-imports": "*",
-                "prettier": "^2.2 || ^3.0",
+                "prettier": "^3.0",
                 "prettier-plugin-astro": "*",
                 "prettier-plugin-css-order": "*",
                 "prettier-plugin-import-sort": "*",
                 "prettier-plugin-jsdoc": "*",
-                "prettier-plugin-marko": "*",
                 "prettier-plugin-organize-attributes": "*",
                 "prettier-plugin-organize-imports": "*",
                 "prettier-plugin-style-order": "*",
-                "prettier-plugin-svelte": "*",
-                "prettier-plugin-twig-melody": "*"
+                "prettier-plugin-svelte": "*"
             },
             "peerDependenciesMeta": {
                 "@ianvs/prettier-plugin-sort-imports": {
@@ -7039,6 +7130,18 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/ts-api-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+            "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.13.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.2.0"
+            }
+        },
         "node_modules/ts-interface-checker": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -7060,27 +7163,6 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
-        },
-        "node_modules/tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^1.8.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            },
-            "peerDependencies": {
-                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-            }
-        },
-        "node_modules/tsutils/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/front/package.json
+++ b/front/package.json
@@ -9,13 +9,12 @@
         "lint": "next lint"
     },
     "dependencies": {
-        "@types/node": "20.4.5",
-        "@types/react": "18.2.18",
+        "@types/node": "20.5.0",
+        "@types/react": "18.2.20",
         "@types/react-dom": "18.2.7",
-        "autoprefixer": "10.4.14",
-        "clsx": "^2.0.0",
+        "autoprefixer": "10.4.15",
         "next": "latest",
-        "postcss": "8.4.26",
+        "postcss": "8.4.27",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-fzf": "^0.1.1",
@@ -24,10 +23,12 @@
     },
     "devDependencies": {
         "@svgr/webpack": "^8.0.1",
-        "eslint": "8.46.0",
-        "eslint-config-next": "13.4.12",
-        "eslint-config-prettier": "^8.9.0",
-        "prettier": "^3.0.0",
-        "prettier-plugin-tailwindcss": "^0.4.1"
+        "@typescript-eslint/eslint-plugin": "^6.4.0",
+        "@typescript-eslint/parser": "^6.4.0",
+        "eslint": "8.47.0",
+        "eslint-config-next": "13.4.16",
+        "eslint-config-prettier": "^9.0.0",
+        "prettier": "^3.0.1",
+        "prettier-plugin-tailwindcss": "^0.5.2"
     }
 }

--- a/front/prettier.config.js
+++ b/front/prettier.config.js
@@ -1,5 +1,0 @@
-// prettier.config.js
-module.exports = {
-    plugins: ["prettier-plugin-tailwindcss"],
-    tabWith: 4,
-};

--- a/front/prettier.config.js
+++ b/front/prettier.config.js
@@ -1,4 +1,5 @@
 // prettier.config.js
 module.exports = {
     plugins: ["prettier-plugin-tailwindcss"],
+    tabWith: 4,
 };


### PR DESCRIPTION
1. eslintrc 파일을 yml에서 json으로 바꿨습니다. 개인적으로 yml이 더 예뻐보이긴 한데... 설정파일이 yaml, json, js 섞여있는것보단 하나로 통일되어있는게 나을 것 같았습니다. 범용성이좋으며, js과 달리 별도의 type: module 같은 추가 설정이 필요없고, 예제 따라하거나 복사하기도 쉬워보여서 json으로 택했습니다. 다른 포맷이 좋으시면 의견 주세요.
2. eslint의 포매팅 규칙 (탭 4, 뉴라인)이 conflict를 일으켜 이를 제거하고 prettier의 설정으로 옮겼습니다. prettier 는 unix newline이 기본 옵션이라, tabWidth만 설정했습니다.
3. eslintrc에 eslint:recommended, typescript-eslint:recommended 설정을 추가했습니다. 대신 이제 React를 명시적으로 import 해야합니다.
4. typescript-eslint를 설치하며 버전문제가 있어서 outdated된 패키지들을 모두 업데이트했습니다. 또한 쓰지않는 clsx를 제거했습니다.

현재 설정으로 적용된 전체 규칙은 `npx eslint --print-config .eslintrc.json` 으로 보실 수 있습니다.

확인해보시고 충돌나거나 문제되는 부분 있으면 알려주시면 감사하겠습니다