### PR TITLE
eslint 규칙을 추가했습니다.

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -9,10 +9,27 @@
     ],
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-type-checked",
         "next/core-web-vitals",
         "prettier"
     ],
-    "rules": {
-    }
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {
+                "@typescript-eslint/no-unused-vars": [
+                    "error", {
+                        "varsIgnorePattern": "^_",
+                        "argsIgnorePattern": "^_"
+                    }
+                ],
+                "@typescript-eslint/strict-boolean-expressions": [
+                    "error"
+                ]
+            },
+            "parserOptions": {
+                "project": ["./tsconfig.json"]
+            }
+        }
+    ]
 }

--- a/front/components/ImageLibrary.tsx
+++ b/front/components/ImageLibrary.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+/* eslint-disable   */
+/* prettier-ignore  */
 import _DoubleSharp from "/public/double-sharp.svg"; export const DoubleSharp = _DoubleSharp;
 import _Logo42 from "/public/logo-42.svg"; export const Logo42 = _Logo42;
 import _LogoGoogle from "/public/logo-google.svg"; export const LogoGoogle = _LogoGoogle;


### PR DESCRIPTION
ImageLibrary를 eslint, prettier에서 제외했습니다

추가한 규칙: [@typescript-eslint/recommended-type-checked](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended-type-checked.ts), strict-boolean-expressions
unused variable은 앞에 _를 붙여 명시적으로 안쓴다고 표시해줄 수 있습니다.

혹시 추가적으로 원하는 규칙 있으면 나중에라도 말씀해주세요

