### PR TITLE
챗 안에서 탭인덱스 + 상호작용 시인성 향상

### DIFF
--- a/front/app/profile/[[...id]]/page.tsx
+++ b/front/app/profile/[[...id]]/page.tsx
@@ -8,6 +8,7 @@ import { GameHistoryPanel } from "@/components/Profile/GameHistoryPanel";
 import { ProfileSection } from "@/components/Profile/ProfileSection";
 import { useNickLookup, usePrivateProfile } from "@/hooks/useProfile";
 import { NICK_NAME_REGEX } from "@/library/payload/profile-constants";
+import type { AccountProfileProtectedPayload } from "@/library/payload/profile-payloads";
 import { useAtomValue } from "jotai";
 import Link from "next/link";
 
@@ -32,43 +33,42 @@ function isValidProfileId(params: string[] | undefined) {
     );
 }
 
+function parseNickAndTag(
+    params: { id?: string[] | undefined },
+    profile: AccountProfileProtectedPayload | undefined,
+): [nick: string, tag: number, isValid: boolean] {
+    const paramKeys = Object.keys(params);
+    const isValid =
+        profile !== undefined &&
+        paramKeys.length === 1 &&
+        paramKeys[0] === "id" &&
+        isValidProfileId(params.id);
+
+    const [nick, tag] =
+        params.id !== undefined
+            ? [params.id[0], Number(params.id[1])]
+            : profile !== undefined
+            ? [profile.nickName ?? "", profile.nickTag]
+            : ["", 0];
+
+    return [nick, tag, isValid];
+}
+
 export default function ProfilePage({
     params,
 }: {
     params: { id?: string[] | undefined };
 }) {
     const profile = usePrivateProfile();
-    const nick =
-        params.id !== undefined ? params.id[0] : profile?.nickName ?? "";
-    const tag =
-        params.id !== undefined ? Number(params.id[1]) : profile?.nickTag ?? 0;
-    const result = useNickLookup(nick, tag);
+    const [nick, tag, isValid] = parseNickAndTag(params, profile);
+    const { accountUUID, isLoading, notFound } = useNickLookup(nick, tag);
     const editPanelVisibility = useAtomValue(EditPanelVisibilityAtom);
-    const accountUUID = result.accountUUID;
 
-    if (profile === undefined) {
+    if (!isValid) {
         return <ErrorPage />;
     }
 
-    if (result.notFound) {
-        return <ErrorPage />;
-    }
-    if (result.isLoading) {
-        return (
-            <>
-                <ProfileSection accountUUID={accountUUID} />
-                <div className="grid h-full w-full grid-cols-1 gap-8 overflow-auto p-4 md:grid-cols-2 lg:grid-cols-4 lg:p-8">
-                    {editPanelVisibility && <EditPanel />}
-                    <AchievementPanel accountUUID={accountUUID} />
-                </div>
-            </>
-        );
-    }
-    const paramKeys = Object.keys(params);
-    if (paramKeys.length !== 1 || paramKeys[0] !== "id") {
-        return <ErrorPage />;
-    }
-    if (!isValidProfileId(params.id)) {
+    if (notFound) {
         return <ErrorPage />;
     }
 
@@ -78,7 +78,7 @@ export default function ProfilePage({
             <div className="grid h-full w-full grid-cols-1 gap-8 overflow-auto p-4 md:grid-cols-2 lg:grid-cols-4 lg:p-8">
                 {editPanelVisibility && <EditPanel />}
                 <AchievementPanel accountUUID={accountUUID} />
-                <GameHistoryPanel accountUUID={accountUUID} />
+                {!isLoading && <GameHistoryPanel accountUUID={accountUUID} />}
             </div>
         </>
     );

--- a/front/app/profile/[[...id]]/page.tsx
+++ b/front/app/profile/[[...id]]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { editPanelVisibilityAtom } from "@/atom/ProfileAtom";
+import { EditPanelVisibilityAtom } from "@/atom/ProfileAtom";
 import { RoundButtonBase } from "@/components/Button/RoundButton";
 import { AchievementPanel } from "@/components/Profile/AchievementPanel";
 import { EditPanel } from "@/components/Profile/EditPanel";
@@ -35,7 +35,7 @@ function isValidProfileId(params: string[] | undefined) {
 export default function ProfilePage({
     params,
 }: {
-    params: { id: string[] | undefined };
+    params: { id?: string[] | undefined };
 }) {
     const profile = usePrivateProfile();
     const nick =
@@ -43,7 +43,7 @@ export default function ProfilePage({
     const tag =
         params.id !== undefined ? Number(params.id[1]) : profile?.nickTag ?? 0;
     const result = useNickLookup(nick, tag);
-    const editPanelVisibility = useAtomValue(editPanelVisibilityAtom);
+    const editPanelVisibility = useAtomValue(EditPanelVisibilityAtom);
     const accountUUID = result.accountUUID;
 
     if (profile === undefined) {

--- a/front/atom/ProfileAtom.tsx
+++ b/front/atom/ProfileAtom.tsx
@@ -1,3 +1,3 @@
 import { atom } from "jotai";
 
-export const editPanelVisibilityAtom = atom(false);
+export const EditPanelVisibilityAtom = atom(false);

--- a/front/components/Button/RoundButton.tsx
+++ b/front/components/Button/RoundButton.tsx
@@ -1,3 +1,6 @@
+// TODO: SquareButton 과 어떻게 어떻게 잘 추상화 혹은 리팩토링 혹은 정리 혹은
+// 귀찮으면 그냥 방치
+
 export function RoundButtonBase({
     children,
     ...props

--- a/front/components/Chat/ChatHeader.tsx
+++ b/front/components/Chat/ChatHeader.tsx
@@ -8,6 +8,18 @@ import { useAtom } from "jotai";
 import { LeftSideBarIsOpenAtom } from "@/atom/ChatAtom";
 import { useEffect } from "react";
 
+export function RightSideBarInput() {
+    return (
+        <input
+            className="peer/right hidden"
+            type="radio"
+            name="rightRadio"
+            id="rightSideBarIcon"
+            defaultChecked
+        />
+    );
+}
+
 export function LeftSideBarInput() {
     const [{ close }, setToClose] = useAtom(LeftSideBarIsOpenAtom);
 

--- a/front/components/Chat/ChatHeader.tsx
+++ b/front/components/Chat/ChatHeader.tsx
@@ -50,7 +50,7 @@ function LeftSidebarButton() {
             />
             <label
                 htmlFor="forOpenLeftSideBar"
-                className="absolute left-4 top-2 z-[5] w-12 overflow-clip transition-all duration-500 peer-checked/headerleft:w-0"
+                className="absolute left-4 top-4 z-[5] w-12 overflow-clip transition-all duration-500 peer-checked/headerleft:w-0"
             >
                 <Icon.Sidebar
                     className="hidden rounded-md p-3 text-gray-200/80 hover:bg-primary/30 active:bg-secondary/80 2xl:block"
@@ -78,7 +78,7 @@ function RightSidebarButton() {
             />
             <label
                 htmlFor="rightHeaderIcon"
-                className="absolute right-4 top-2 z-[5] w-12 overflow-clip transition-all duration-500 peer-checked/headerright:w-0"
+                className="absolute right-4 top-4 z-[5] w-12 overflow-clip transition-all duration-500 peer-checked/headerright:w-0"
             >
                 <Icon.MembersFilled
                     className="rounded-md p-3 text-gray-50/80 hover:bg-primary/30 active:bg-secondary/80"
@@ -98,7 +98,7 @@ export function ChatHeader() {
     const desc = "채팅을 채팅채팅~"; // TODO: 이거 설정 가능하게 하나요?
 
     return (
-        <div className="group relative flex h-fit shrink-0 select-none flex-col items-center justify-center self-stretch bg-transparent py-2">
+        <div className="group relative flex h-fit shrink-0 select-none flex-col items-center justify-center self-stretch bg-transparent py-4">
             <LeftSidebarButton />
             <div className="overflow-hidden">
                 <label

--- a/front/components/Chat/ChatHeader.tsx
+++ b/front/components/Chat/ChatHeader.tsx
@@ -13,7 +13,7 @@ export function LeftSideBarInput() {
 
     return (
         <input
-            className="peer/left hidden"
+            className="peer/left invisible absolute"
             type="radio"
             onClick={() => {
                 setToClose(false);

--- a/front/components/Chat/ChatHeader.tsx
+++ b/front/components/Chat/ChatHeader.tsx
@@ -18,6 +18,7 @@ export function LeftSideBarInput() {
             onClick={() => {
                 setToClose(false);
             }}
+            readOnly
             checked={close}
             name="leftRadio"
             id="forCloseLeftSideBar"
@@ -39,6 +40,7 @@ function LeftSidebarButton() {
     return (
         <>
             <input
+                readOnly
                 className="peer/headerleft hidden"
                 checked={open}
                 onClick={() => setToOpen(true)}

--- a/front/components/Chat/ChatHeader.tsx
+++ b/front/components/Chat/ChatHeader.tsx
@@ -21,14 +21,14 @@ export function RightSideBarInput() {
 }
 
 export function LeftSideBarInput() {
-    const [{ close }, setToClose] = useAtom(LeftSideBarIsOpenAtom);
+    const [{ close }, setToOpen] = useAtom(LeftSideBarIsOpenAtom);
 
     return (
         <input
             className="peer/left invisible absolute"
             type="radio"
             onClick={() => {
-                setToClose(false);
+                setToOpen(false);
             }}
             readOnly
             checked={close}

--- a/front/components/Chat/ChatLayout.tsx
+++ b/front/components/Chat/ChatLayout.tsx
@@ -1,23 +1,12 @@
-import { LeftSideBarInput } from "./ChatHeader";
-import ChatLeftSideBar from "./ChatLeftSideBar";
-import ChatMainPage from "./ChatMainPage";
-import ChatRightSideBar from "./ChatRightSideBar";
+import { LeftSideBarInput, RightSideBarInput } from "./ChatHeader";
 
-export default function ChatLayout() {
+export default function ChatLayout({ children }: React.PropsWithChildren) {
     return (
-        <div className="gradient-border back-full flex h-full w-full items-center justify-center rounded-[28px] p-px before:rounded-[28px] before:p-px 2xl:min-w-[80rem]">
+        <div className="gradient-border back-full relative flex h-full w-full items-center justify-center rounded-[28px] p-px before:rounded-[28px] before:p-px 2xl:w-fit 2xl:min-w-[80rem]">
             <div className="back-full relative flex h-full w-full flex-row overflow-hidden rounded-[28px] bg-windowGlass/30 before:backdrop-blur-[50px]">
                 <LeftSideBarInput />
-                <ChatLeftSideBar />
-                <ChatMainPage />
-                <input
-                    className="peer/right hidden"
-                    type="radio"
-                    name="rightRadio"
-                    id="rightSideBarIcon"
-                    defaultChecked
-                />
-                <ChatRightSideBar />
+                <RightSideBarInput />
+                {children}
             </div>
         </div>
     );

--- a/front/components/Chat/ChatLeftSideBar.tsx
+++ b/front/components/Chat/ChatLeftSideBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useState } from "react";
+import { useState } from "react";
 import { Icon } from "@/components/ImageLibrary";
 import ChatRoomBlock from "./ChatRoomBlock";
 import { TextField } from "@/components/TextField";
@@ -9,7 +9,7 @@ import { Provider, useAtom, useAtomValue } from "jotai";
 import { ChatRoomListAtom, CreateNewRoomCheckedAtom } from "@/atom/ChatAtom";
 
 import { FzfHighlight, useFzf } from "react-fzf";
-import { Tab, Transition } from "@headlessui/react";
+import { Tab } from "@headlessui/react";
 import type { ChatRoomEntry } from "@/library/payload/chat-payloads";
 
 function classNames(...classes: string[]) {

--- a/front/components/Chat/ChatLeftSideBar.tsx
+++ b/front/components/Chat/ChatLeftSideBar.tsx
@@ -29,7 +29,7 @@ export default function ChatLeftSideBar() {
                     <label
                         data-checked={createNewRoomChecked}
                         htmlFor="CreateNewRoom"
-                        className="relative flex h-12 items-center gap-2 rounded-md p-4 hover:bg-primary/30 hover:text-white data-[checked=true]:bg-secondary/80"
+                        className="relative flex h-12 items-center gap-2 rounded-md p-4 outline-none hover:bg-primary/30 hover:text-white focus-visible:outline-primary/70 data-[checked=true]:bg-secondary/80"
                     >
                         <Icon.Edit className="" width={17} height={17} />
                         <p className="font-sans text-base leading-4">
@@ -37,7 +37,7 @@ export default function ChatLeftSideBar() {
                         </p>
                     </label>
 
-                    <label htmlFor="forCloseLeftSideBar">
+                    <label tabIndex={0} htmlFor="forCloseLeftSideBar">
                         <Icon.Sidebar
                             className="hidden rounded-md p-3 text-gray-200/80 hover:bg-primary/30 hover:text-white active:bg-secondary/80 2xl:block"
                             width={48}

--- a/front/components/Chat/ChatLeftSideBar.tsx
+++ b/front/components/Chat/ChatLeftSideBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { Icon } from "@/components/ImageLibrary";
 import ChatRoomBlock from "./ChatRoomBlock";
 import { TextField } from "@/components/TextField";
@@ -9,93 +9,163 @@ import { Provider, useAtom, useAtomValue } from "jotai";
 import { ChatRoomListAtom, CreateNewRoomCheckedAtom } from "@/atom/ChatAtom";
 
 import { FzfHighlight, useFzf } from "react-fzf";
+import { Tab, Transition } from "@headlessui/react";
+import type { ChatRoomEntry } from "@/library/payload/chat-payloads";
+
+function classNames(...classes: string[]) {
+    return classes.filter(Boolean).join(" ");
+}
 
 export default function ChatLeftSideBar() {
-    const chatRoomList = useAtomValue(ChatRoomListAtom);
+    const chatJoinRoomList = useAtomValue(ChatRoomListAtom);
+    const chatPublicRoomList = useAtomValue(ChatRoomListAtom);
     const [query, setQuery] = useState("");
+    const categories = {
+        참가방: chatJoinRoomList,
+        공개방: chatPublicRoomList,
+    };
+
     const [createNewRoomChecked, setCreateNewRoomChecked] = useAtom(
         CreateNewRoomCheckedAtom,
     );
+
+    return (
+        <ChatLeftSideBarLayout>
+            <div className="flex h-fit shrink-0 flex-row items-center justify-between self-stretch py-2 peer-checked:text-gray-200/80">
+                <label
+                    data-checked={createNewRoomChecked}
+                    tabIndex={0}
+                    htmlFor="CreateNewRoom"
+                    className="relative flex h-12 items-center gap-2 rounded-md p-4 outline-none hover:bg-primary/30 hover:transition-all focus-visible:outline-primary/70 data-[checked=true]:scale-105 data-[checked=true]:bg-secondary/80"
+                >
+                    <Icon.Edit className="" width={17} height={17} />
+                    <p className="font-sans text-base leading-4">방 만들기</p>
+                </label>
+
+                <label tabIndex={0} htmlFor="forCloseLeftSideBar">
+                    <Icon.Sidebar
+                        className="hidden rounded-md p-3 text-gray-200/80 hover:bg-primary/30 hover:text-white active:bg-secondary/80 2xl:block"
+                        width={48}
+                        height={48}
+                    />
+                    <Icon.Hamburger
+                        className="block rounded-md p-3 text-gray-200/80 hover:bg-primary/30 hover:text-white active:bg-secondary/80 2xl:hidden"
+                        width={48}
+                        height={48}
+                    />
+                </label>
+            </div>
+
+            <input
+                type="checkbox"
+                checked={createNewRoomChecked}
+                onChange={(e) => setCreateNewRoomChecked(e.target.checked)}
+                id="CreateNewRoom"
+                className="peer hidden"
+            />
+
+            <Tab.Group>
+                <Tab.List
+                    onClick={() => setQuery("")}
+                    className="flex h-10 w-full space-x-1 rounded-lg bg-black/30 p-1"
+                >
+                    {Object.keys(categories).map((category) => (
+                        <Tab
+                            key={category}
+                            className={({ selected }) =>
+                                classNames(
+                                    "w-full rounded-lg py-1 text-sm font-medium leading-5 text-gray-50/70",
+                                    "outline-none focus-within:outline-primary/30",
+                                    selected
+                                        ? "bg-secondary/30 shadow"
+                                        : "hover:bg-primary/30 hover:text-white",
+                                )
+                            }
+                        >
+                            {category}
+                        </Tab>
+                    ))}
+                </Tab.List>
+                <Tab.Panels className="w-full">
+                    <ListQuaryTextField
+                        value={query}
+                        onChange={(event) => setQuery(event.target.value)}
+                    />
+                    {Object.values(categories).map((rooms, idx) => (
+                        <Tab.Panel key={idx}>
+                            <RoomPanel rooms={rooms} query={query} />
+                        </Tab.Panel>
+                    ))}
+                </Tab.Panels>
+            </Tab.Group>
+
+            <Provider>
+                <CreateNewRoom />
+            </Provider>
+        </ChatLeftSideBarLayout>
+    );
+}
+
+function ChatLeftSideBarLayout({ children }: React.PropsWithChildren) {
+    return (
+        <div className="absolute z-10 h-full w-[310px] min-w-[310px] select-none overflow-clip bg-black/30 text-gray-200/80 backdrop-blur-[50px] transition-all duration-100 peer-checked/left:w-0 peer-checked/left:min-w-0 peer-checked/left:p-0 2xl:relative 2xl:flex 2xl:rounded-[0px_28px_28px_0px]">
+            <div className="flex h-full w-[310px] shrink-0 flex-col items-start gap-2 px-4 py-2 2xl:py-4">
+                {children}
+            </div>
+        </div>
+    );
+}
+
+function RoomPanel({
+    rooms,
+    query,
+}: {
+    rooms: ChatRoomEntry[];
+    query: string;
+}) {
     const { results, getFzfHighlightProps } = useFzf({
-        items: chatRoomList,
+        items: rooms,
         itemToString: (item) => item.title,
         query,
     });
 
+    return results.map((item, index) => (
+        <ChatRoomBlock key={item.id} chatRoom={item}>
+            <FzfHighlight
+                {...getFzfHighlightProps({
+                    index,
+                    item,
+                    className: "text-yellow-500",
+                })}
+            />
+        </ChatRoomBlock>
+    ));
+}
+
+function ListQuaryTextField({
+    value,
+    onChange,
+}: {
+    value: string;
+    onChange: React.ChangeEventHandler<HTMLInputElement>;
+}) {
     return (
-        <div className="absolute z-10 h-full w-[310px] min-w-[310px] select-none overflow-clip bg-black/30 text-gray-200/80 backdrop-blur-[50px] transition-all duration-100 peer-checked/left:w-0 peer-checked/left:min-w-0 peer-checked/left:p-0 2xl:relative 2xl:flex 2xl:rounded-[0px_28px_28px_0px]">
-            <div className="flex h-full w-[310px] shrink-0 flex-col items-start gap-2 px-4 py-2 2xl:py-4">
-                <div className="flex h-fit shrink-0 flex-row items-center justify-between self-stretch py-2 peer-checked:text-gray-200/80">
-                    <label
-                        data-checked={createNewRoomChecked}
-                        tabIndex={0}
-                        htmlFor="CreateNewRoom"
-                        className="relative flex h-12 items-center gap-2 rounded-md p-4 outline-none hover:bg-primary/30 hover:transition-all focus-visible:outline-primary/70 data-[checked=true]:scale-105 data-[checked=true]:bg-secondary/80"
-                    >
-                        <Icon.Edit className="" width={17} height={17} />
-                        <p className="font-sans text-base leading-4">
-                            방 만들기
-                        </p>
-                    </label>
-
-                    <label tabIndex={0} htmlFor="forCloseLeftSideBar">
-                        <Icon.Sidebar
-                            className="hidden rounded-md p-3 text-gray-200/80 hover:bg-primary/30 hover:text-white active:bg-secondary/80 2xl:block"
-                            width={48}
-                            height={48}
-                        />
-                        <Icon.Hamburger
-                            className="block rounded-md p-3 text-gray-200/80 hover:bg-primary/30 hover:text-white active:bg-secondary/80 2xl:hidden"
-                            width={48}
-                            height={48}
-                        />
-                    </label>
-                </div>
-
-                <input
-                    type="checkbox"
-                    checked={createNewRoomChecked}
-                    onChange={(e) => setCreateNewRoomChecked(e.target.checked)}
-                    id="CreateNewRoom"
-                    className="peer hidden"
-                />
-
-                <div className="flex w-full flex-col gap-2 overflow-auto peer-checked:hidden">
-                    <TextField
-                        type="search"
-                        icon={
-                            <Icon.Search
-                                className="absolute left-1 right-1 top-1 select-none rounded-md p-1 transition-all group-focus-within:left-[15.5rem] group-focus-within:bg-secondary group-focus-within:text-white"
-                                width={24}
-                                height={24}
-                            />
-                        }
-                        className="py-1 pl-7 pr-2 text-sm transition-all focus-within:pl-2 focus-within:pr-9 peer-checked:hidden"
-                        value={query}
-                        placeholder="Search..."
-                        autoFocus={false}
-                        onChange={(event) => setQuery(event.target.value)}
+        <div className="mb-2 flex w-full flex-col gap-2 overflow-auto peer-checked:hidden">
+            <TextField
+                type="search"
+                icon={
+                    <Icon.Search
+                        className="absolute left-1 right-1 top-1 select-none rounded-md p-1 transition-all group-focus-within:left-[15.5rem] group-focus-within:bg-secondary group-focus-within:text-white"
+                        width={24}
+                        height={24}
                     />
-
-                    <div className="h-fit w-full p-1">
-                        {results.map((item, index) => (
-                            <ChatRoomBlock key={item.id} chatRoom={item}>
-                                <FzfHighlight
-                                    {...getFzfHighlightProps({
-                                        index,
-                                        item,
-                                        className: "text-yellow-500",
-                                    })}
-                                />
-                            </ChatRoomBlock>
-                        ))}
-                    </div>
-                </div>
-
-                <Provider>
-                    <CreateNewRoom />
-                </Provider>
-            </div>
+                }
+                className="py-1 pl-7 pr-2 text-sm transition-all focus-within:pl-2 focus-within:pr-9 peer-checked:hidden"
+                placeholder="Search..."
+                autoFocus={false}
+                value={value}
+                onChange={onChange}
+            />
         </div>
     );
 }

--- a/front/components/Chat/ChatLeftSideBar.tsx
+++ b/front/components/Chat/ChatLeftSideBar.tsx
@@ -77,7 +77,7 @@ export default function ChatLeftSideBar() {
                         onChange={(event) => setQuery(event.target.value)}
                     />
 
-                    <div className="h-fit w-full overflow-auto">
+                    <div className="h-fit w-full p-1">
                         {results.map((item, index) => (
                             <ChatRoomBlock key={item.id} chatRoom={item}>
                                 <FzfHighlight

--- a/front/components/Chat/ChatLeftSideBar.tsx
+++ b/front/components/Chat/ChatLeftSideBar.tsx
@@ -17,6 +17,7 @@ function classNames(...classes: string[]) {
 }
 
 export default function ChatLeftSideBar() {
+    // TODO: 두개 다른 atom 써야함
     const chatJoinRoomList = useAtomValue(ChatRoomListAtom);
     const chatPublicRoomList = useAtomValue(ChatRoomListAtom);
     const [query, setQuery] = useState("");

--- a/front/components/Chat/ChatLeftSideBar.tsx
+++ b/front/components/Chat/ChatLeftSideBar.tsx
@@ -25,11 +25,12 @@ export default function ChatLeftSideBar() {
     return (
         <div className="absolute z-10 h-full w-[310px] min-w-[310px] select-none overflow-clip bg-black/30 text-gray-200/80 backdrop-blur-[50px] transition-all duration-100 peer-checked/left:w-0 peer-checked/left:min-w-0 peer-checked/left:p-0 2xl:relative 2xl:flex 2xl:rounded-[0px_28px_28px_0px]">
             <div className="flex h-full w-[310px] shrink-0 flex-col items-start gap-2 px-4 py-2 2xl:py-4">
-                <div className="flex h-fit shrink-0 flex-row items-center justify-between self-stretch peer-checked:text-gray-200/80 2xl:py-2">
+                <div className="flex h-fit shrink-0 flex-row items-center justify-between self-stretch py-2 peer-checked:text-gray-200/80">
                     <label
                         data-checked={createNewRoomChecked}
+                        tabIndex={0}
                         htmlFor="CreateNewRoom"
-                        className="relative flex h-12 items-center gap-2 rounded-md p-4 outline-none hover:bg-primary/30 hover:text-white focus-visible:outline-primary/70 data-[checked=true]:bg-secondary/80"
+                        className="relative flex h-12 items-center gap-2 rounded-md p-4 outline-none hover:bg-primary/30 hover:transition-all focus-visible:outline-primary/70 data-[checked=true]:scale-105 data-[checked=true]:bg-secondary/80"
                     >
                         <Icon.Edit className="" width={17} height={17} />
                         <p className="font-sans text-base leading-4">

--- a/front/components/Chat/ChatMainPage.tsx
+++ b/front/components/Chat/ChatMainPage.tsx
@@ -1,11 +1,10 @@
 import { ChatHeader } from "./ChatHeader";
 import { ChatDialog } from "./ChatDialog";
 
-export default function ChatMainPage() {
+export default function ChatMainPage({ children }: React.PropsWithChildren) {
     return (
         <div className="flex-grow-1 relative flex h-full w-full flex-col items-start bg-transparent transition-all 2xl:gap-4 2xl:p-4">
-            <ChatHeader />
-            <ChatDialog innerFrame={"2xl:rounded-lg"} outerFrame={"w-full"} />
+            {children}
         </div>
     );
 }

--- a/front/components/Chat/ChatMainPage.tsx
+++ b/front/components/Chat/ChatMainPage.tsx
@@ -1,6 +1,3 @@
-import { ChatHeader } from "./ChatHeader";
-import { ChatDialog } from "./ChatDialog";
-
 export default function ChatMainPage({ children }: React.PropsWithChildren) {
     return (
         <div className="flex-grow-1 relative flex h-full w-full flex-col items-start bg-transparent transition-all 2xl:gap-4 2xl:p-4">

--- a/front/components/Chat/ChatRightSideBar.tsx
+++ b/front/components/Chat/ChatRightSideBar.tsx
@@ -134,7 +134,7 @@ export default function ChatRightSideBar() {
     return (
         <div className="absolute right-0 top-0 z-10 h-full w-[310px] min-w-[310px] select-none overflow-hidden rounded-[0px_28px_28px_0px] bg-black/30 text-gray-200/80 backdrop-blur-[50px] transition-all duration-100 peer-checked/right:w-0 peer-checked/right:min-w-0 2xl:relative 2xl:flex 2xl:rounded-[28px] 2xl:bg-black/30">
             <div className="flex h-full w-full shrink-0 flex-col items-start gap-2 px-4 py-2 2xl:py-4">
-                <div className="flex h-fit shrink-0 flex-row items-start justify-between gap-2 self-stretch 2xl:py-2">
+                <div className="flex h-fit shrink-0 flex-row items-start justify-between gap-2 self-stretch py-2 ">
                     <label htmlFor="rightSideBarIcon">
                         <Icon.MembersFilled
                             className="rounded-md p-3 text-gray-50/80 hover:bg-primary/30 active:bg-secondary/80"
@@ -144,13 +144,13 @@ export default function ChatRightSideBar() {
                     </label>
                     <div
                         data-checked={memberListDropDown}
-                        className="group w-full overflow-hidden"
+                        className="group w-full"
                     >
                         <label
                             onClick={handleList}
                             htmlFor="memberListDropDown"
                             data-current-list={currentPage}
-                            className={`group flex h-12 w-full items-center justify-center gap-2 rounded-md p-4 data-[current-list]:bg-primary/80 data-[current-list]:text-white ${
+                            className={`group flex h-12 w-full items-center justify-center gap-2 rounded-md p-4 data-[current-list]:scale-105 data-[current-list]:bg-primary/80 data-[current-list]:text-white data-[current-list]:transition-all ${
                                 admin &&
                                 "hover:bg-primary/30 hover:text-white active:bg-secondary/80"
                             }`}

--- a/front/components/Chat/ChatRoomBlock.tsx
+++ b/front/components/Chat/ChatRoomBlock.tsx
@@ -50,7 +50,7 @@ export default function ChatRoomBlock({
                 setChatRoomUUID(chatRoom.id);
                 setLeftSideBar(false);
             }}
-            className="relative w-full rounded-lg px-2 hover:bg-primary/30 active:bg-secondary/80"
+            className="relative w-full rounded-lg px-2 outline-none focus-within:outline-primary/70 hover:bg-primary/30 active:bg-secondary/80"
         >
             {/* chatrooms - image */}
             <div className="flex h-fit flex-row items-center gap-4 self-stretch">

--- a/front/components/NavigationBar/ChatButton.tsx
+++ b/front/components/NavigationBar/ChatButton.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React, { Fragment, useRef, useState } from "react";
 import { Icon } from "@/components/ImageLibrary";
-import { Dialog } from "@headlessui/react";
+import { Dialog, Transition } from "@headlessui/react";
 import { useChatRoomTotalUnreadCount } from "@/hooks/useChatRoom";
 import { NotificationBadge } from "./NotificationBadge";
 import ChatLayout from "@/components/Chat/ChatLayout";
@@ -32,29 +32,48 @@ export function ChatButton() {
 
     return (
         <>
-            <Dialog
-                open={isOpen}
-                initialFocus={ref}
-                onClose={() => setIsOpen(false)}
-            >
-                <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+            <Transition show={isOpen}>
+                <Dialog initialFocus={ref} onClose={() => setIsOpen(false)}>
+                    <Transition.Child
+                        enter="ease-out duration-300"
+                        enterFrom="opacity-0"
+                        enterTo="opacity-100"
+                        leave="ease-in duration-100"
+                        leaveFrom="opacity-100"
+                        leaveTo="opacity-0"
+                    >
+                        <div
+                            className="fixed inset-0 bg-black/30"
+                            aria-hidden="true"
+                        />
+                    </Transition.Child>
 
-                <div className="fixed inset-0 flex w-screen items-center justify-center">
-                    <Dialog.Panel className="absolute inset-0 top-12 mx-auto max-w-7xl lg:inset-32">
-                        <ChatLayout>
-                            <ChatLeftSideBar />
-                            <ChatMainPage>
-                                <ChatHeader />
-                                <ChatDialog
-                                    innerFrame={"2xl:rounded-lg"}
-                                    outerFrame={"w-full"}
-                                />
-                            </ChatMainPage>
-                            <ChatRightSideBar />
-                        </ChatLayout>
-                    </Dialog.Panel>
-                </div>
-            </Dialog>
+                    <Transition.Child
+                        enter="ease-in-out duration-300"
+                        enterFrom="scale-75"
+                        enterTo="scale-100"
+                        className="fixed inset-0 flex w-screen transform-gpu items-center justify-center"
+                    >
+                        <Dialog.Panel className="absolute inset-0 top-12 mx-auto max-w-7xl lg:inset-32">
+                            <ChatLayout>
+                                <ChatLeftSideBar />
+                                <ChatMainPage>
+                                    <Dialog.Title className="relative w-full">
+                                        <ChatHeader />
+                                    </Dialog.Title>
+                                    <Dialog.Description className="relative h-full w-full">
+                                        <ChatDialog
+                                            innerFrame={"2xl:rounded-lg"}
+                                            outerFrame={"w-full"}
+                                        />
+                                    </Dialog.Description>
+                                </ChatMainPage>
+                                <ChatRightSideBar />
+                            </ChatLayout>
+                        </Dialog.Panel>
+                    </Transition.Child>
+                </Dialog>
+            </Transition>
             <button
                 onClick={() => setIsOpen(true)}
                 ref={ref}

--- a/front/components/NavigationBar/ChatButton.tsx
+++ b/front/components/NavigationBar/ChatButton.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import React, { useRef, useState } from "react";
-import { Icon } from "../ImageLibrary";
+import { Icon } from "@/components/ImageLibrary";
 import { Dialog } from "@headlessui/react";
-import ChatLayout from "../Chat/ChatLayout";
 import { useChatRoomTotalUnreadCount } from "@/hooks/useChatRoom";
 import { NotificationBadge } from "./NotificationBadge";
+import ChatLayout from "@/components/Chat/ChatLayout";
+import ChatLeftSideBar from "@/components/Chat/ChatLeftSideBar";
+import ChatMainPage from "@/components/Chat/ChatMainPage";
+import ChatRightSideBar from "@/components/Chat/ChatRightSideBar";
+import { ChatHeader } from "@/components/Chat/ChatHeader";
+import { ChatDialog } from "@/components/Chat/ChatDialog";
 
 export function ChatButton() {
     const [isOpen, setIsOpen] = useState(false);
@@ -32,11 +37,23 @@ export function ChatButton() {
                 initialFocus={ref}
                 onClose={() => setIsOpen(false)}
             >
-                <Dialog.Panel className="absolute inset-0 top-16 flex items-center justify-center lg:inset-x-1/2 lg:inset-y-32">
-                    <div className="relative flex h-full w-full justify-center 2xl:w-fit">
-                        <ChatLayout />
-                    </div>
-                </Dialog.Panel>
+                <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+
+                <div className="fixed inset-0 flex w-screen items-center justify-center">
+                    <Dialog.Panel className="absolute inset-0 top-12 mx-auto max-w-7xl lg:inset-32">
+                        <ChatLayout>
+                            <ChatLeftSideBar />
+                            <ChatMainPage>
+                                <ChatHeader />
+                                <ChatDialog
+                                    innerFrame={"2xl:rounded-lg"}
+                                    outerFrame={"w-full"}
+                                />
+                            </ChatMainPage>
+                            <ChatRightSideBar />
+                        </ChatLayout>
+                    </Dialog.Panel>
+                </div>
             </Dialog>
             <button
                 onClick={() => setIsOpen(true)}

--- a/front/components/NavigationBar/ChatButton.tsx
+++ b/front/components/NavigationBar/ChatButton.tsx
@@ -6,12 +6,13 @@ import { useAtomValue } from "jotai";
 import { FriendRequestEntryAtom } from "@/atom/FriendAtom";
 import { Dialog } from "@headlessui/react";
 import ChatLayout from "../Chat/ChatLayout";
-import { usePathname } from "next/navigation";
 
 export function ChatButton() {
+    //TODO: check by  unread message not FriendRequestEntryAtom
     const accountUUIDs = useAtomValue(FriendRequestEntryAtom);
     const [isOpen, setIsOpen] = useState(false);
     const ref = useRef<HTMLButtonElement>(null);
+
     const ChatIcon = isOpen ? Icon.ChatFilled : Icon.ChatOutlined;
 
     return (
@@ -30,9 +31,9 @@ export function ChatButton() {
             <button
                 onClick={() => setIsOpen(true)}
                 ref={ref}
-                className="relative flex h-fit w-fit"
+                className="relative flex h-fit w-fit rounded outline-none focus-visible:outline-primary/70"
             >
-                <ChatIcon className="h-12 w-12 rounded-lg p-2 shadow-white drop-shadow-[0_0_0.1rem_#ffffff30] hover:bg-primary/30 hover:text-white/80 focus:bg-controlsSelected active:bg-secondary 2xl:h-14 2xl:w-14" />
+                <ChatIcon className="h-12 w-12 rounded-lg p-2 shadow-white drop-shadow-[0_0_0.1rem_#ffffff30] hover:bg-primary/30 hover:text-white/80 active:bg-secondary 2xl:h-14 2xl:w-14" />
                 {accountUUIDs.length !== 0 && (
                     <div className="absolute right-2 top-2 flex h-fit w-fit rounded-lg bg-red-500/90 p-1">
                         <div className="h-1 w-1 rounded-full bg-white"></div>

--- a/front/components/NavigationBar/ChatButton.tsx
+++ b/front/components/NavigationBar/ChatButton.tsx
@@ -13,7 +13,7 @@ export function ChatButton() {
     const accountUUIDs = useAtomValue(FriendRequestEntryAtom);
     const [isOpen, setIsOpen] = useState(false);
     const ref = useRef<HTMLButtonElement>(null);
-    const totalUnReadMessage = useChatRoomTotalUnreadCount();
+    const totalUnreadMessages = useChatRoomTotalUnreadCount();
 
     const ChatIcon = isOpen ? Icon.ChatFilled : Icon.ChatOutlined;
 
@@ -36,7 +36,7 @@ export function ChatButton() {
                 className="relative flex h-fit w-fit rounded outline-none focus-visible:outline-primary/70"
             >
                 <ChatIcon className="h-12 w-12 rounded-lg p-2 shadow-white drop-shadow-[0_0_0.1rem_#ffffff30] hover:bg-primary/30 hover:text-white/80 active:bg-secondary 2xl:h-14 2xl:w-14" />
-                {totalUnReadMessage !== 0 && (
+                {totalUnreadMessages !== 0 && (
                     <div className="absolute right-2 top-2 flex h-fit w-fit rounded-lg bg-red-500/90 p-1">
                         <div className="h-1 w-1 rounded-full bg-white"></div>
                     </div>

--- a/front/components/NavigationBar/ChatButton.tsx
+++ b/front/components/NavigationBar/ChatButton.tsx
@@ -32,7 +32,7 @@ export function ChatButton() {
                 initialFocus={ref}
                 onClose={() => setIsOpen(false)}
             >
-                <Dialog.Panel className="absolute inset-0 top-16 flex items-center justify-center lg:inset-32 lg:bottom-16">
+                <Dialog.Panel className="absolute inset-0 top-16 flex items-center justify-center lg:inset-x-1/2 lg:inset-y-32">
                     <div className="relative flex h-full w-full justify-center 2xl:w-fit">
                         <ChatLayout />
                     </div>

--- a/front/components/NavigationBar/ChatButton.tsx
+++ b/front/components/NavigationBar/ChatButton.tsx
@@ -6,12 +6,14 @@ import { useAtomValue } from "jotai";
 import { FriendRequestEntryAtom } from "@/atom/FriendAtom";
 import { Dialog } from "@headlessui/react";
 import ChatLayout from "../Chat/ChatLayout";
+import { useChatRoomTotalUnreadCount } from "@/hooks/useChatRoom";
 
 export function ChatButton() {
     //TODO: check by  unread message not FriendRequestEntryAtom
     const accountUUIDs = useAtomValue(FriendRequestEntryAtom);
     const [isOpen, setIsOpen] = useState(false);
     const ref = useRef<HTMLButtonElement>(null);
+    const totalUnReadMessage = useChatRoomTotalUnreadCount();
 
     const ChatIcon = isOpen ? Icon.ChatFilled : Icon.ChatOutlined;
 
@@ -34,7 +36,7 @@ export function ChatButton() {
                 className="relative flex h-fit w-fit rounded outline-none focus-visible:outline-primary/70"
             >
                 <ChatIcon className="h-12 w-12 rounded-lg p-2 shadow-white drop-shadow-[0_0_0.1rem_#ffffff30] hover:bg-primary/30 hover:text-white/80 active:bg-secondary 2xl:h-14 2xl:w-14" />
-                {accountUUIDs.length !== 0 && (
+                {totalUnReadMessage !== 0 && (
                     <div className="absolute right-2 top-2 flex h-fit w-fit rounded-lg bg-red-500/90 p-1">
                         <div className="h-1 w-1 rounded-full bg-white"></div>
                     </div>

--- a/front/components/NavigationBar/ChatButton.tsx
+++ b/front/components/NavigationBar/ChatButton.tsx
@@ -5,6 +5,7 @@ import { Icon } from "../ImageLibrary";
 import { Dialog } from "@headlessui/react";
 import ChatLayout from "../Chat/ChatLayout";
 import { useChatRoomTotalUnreadCount } from "@/hooks/useChatRoom";
+import { NotificationBadge } from "./NotificationBadge";
 
 export function ChatButton() {
     const [isOpen, setIsOpen] = useState(false);
@@ -43,11 +44,8 @@ export function ChatButton() {
                 className="relative flex h-fit w-fit rounded outline-none focus-visible:outline-primary/70"
             >
                 {ChatIcon}
-                {totalUnreadMessages !== 0 && (
-                    <div className="absolute right-2 top-2 flex h-fit w-fit rounded-lg bg-red-500/90 p-1">
-                        <div className="h-1 w-1 rounded-full bg-white"></div>
-                    </div>
-                )}
+                {totalUnreadMessages !== undefined &&
+                    totalUnreadMessages !== 0 && <NotificationBadge />}
             </button>
         </>
     );

--- a/front/components/NavigationBar/ChatButton.tsx
+++ b/front/components/NavigationBar/ChatButton.tsx
@@ -2,20 +2,27 @@
 
 import React, { useRef, useState } from "react";
 import { Icon } from "../ImageLibrary";
-import { useAtomValue } from "jotai";
-import { FriendRequestEntryAtom } from "@/atom/FriendAtom";
 import { Dialog } from "@headlessui/react";
 import ChatLayout from "../Chat/ChatLayout";
 import { useChatRoomTotalUnreadCount } from "@/hooks/useChatRoom";
 
 export function ChatButton() {
-    //TODO: check by  unread message not FriendRequestEntryAtom
-    const accountUUIDs = useAtomValue(FriendRequestEntryAtom);
     const [isOpen, setIsOpen] = useState(false);
     const ref = useRef<HTMLButtonElement>(null);
     const totalUnreadMessages = useChatRoomTotalUnreadCount();
 
-    const ChatIcon = isOpen ? Icon.ChatFilled : Icon.ChatOutlined;
+    const iconClassName = [
+        "h-12 w-12 rounded-lg p-2 shadow-white",
+        "drop-shadow-[0_0_0.1rem_#ffffff30]",
+        "hover:bg-primary/30 hover:text-white/80",
+        "active:bg-secondary 2xl:h-14 2xl:w-14",
+    ].join(" ");
+
+    const ChatIcon = isOpen ? (
+        <Icon.ChatFilled className={iconClassName} />
+    ) : (
+        <Icon.ChatOutlined className={iconClassName} />
+    );
 
     return (
         <>
@@ -35,7 +42,7 @@ export function ChatButton() {
                 ref={ref}
                 className="relative flex h-fit w-fit rounded outline-none focus-visible:outline-primary/70"
             >
-                <ChatIcon className="h-12 w-12 rounded-lg p-2 shadow-white drop-shadow-[0_0_0.1rem_#ffffff30] hover:bg-primary/30 hover:text-white/80 active:bg-secondary 2xl:h-14 2xl:w-14" />
+                {ChatIcon}
                 {totalUnreadMessages !== 0 && (
                     <div className="absolute right-2 top-2 flex h-fit w-fit rounded-lg bg-red-500/90 p-1">
                         <div className="h-1 w-1 rounded-full bg-white"></div>

--- a/front/components/NavigationBar/FriendButton.tsx
+++ b/front/components/NavigationBar/FriendButton.tsx
@@ -6,12 +6,24 @@ import { FriendModal } from "../FriendModal/FriendModal";
 import { useAtomValue } from "jotai";
 import { FriendRequestEntryAtom } from "@/atom/FriendAtom";
 import { Dialog } from "@headlessui/react";
+import { NotificationBadge } from "./NotificationBadge";
 
 export function FriendButton() {
     const accountUUIDs = useAtomValue(FriendRequestEntryAtom);
     const [isOpen, setIsOpen] = useState(false);
 
-    const MemberIcon = isOpen ? Icon.MembersFilled : Icon.MembersOutLined;
+    const iconClassName = [
+        "h-12 w-12 rounded-lg p-3 shadow-white",
+        "drop-shadow-[0_0_0.1rem_#ffffff30]",
+        "hover:bg-primary/30 hover:text-white/80",
+        "active:bg-secondary 2xl:h-14 2xl:w-14",
+    ].join(" ");
+
+    const MemberIcon = isOpen ? (
+        <Icon.MembersFilled className={iconClassName} />
+    ) : (
+        <Icon.MembersOutLined className={iconClassName} />
+    );
 
     return (
         <>
@@ -26,12 +38,8 @@ export function FriendButton() {
                 onClick={() => setIsOpen(true)}
                 className="relative flex h-fit w-fit rounded outline-none focus-visible:outline-primary/70"
             >
-                <MemberIcon className="h-12 w-12 rounded-lg p-3 shadow-white drop-shadow-[0_0_0.1rem_#ffffff30] hover:bg-primary/30 hover:text-white/80 focus:bg-controlsSelected active:bg-secondary 2xl:h-14 2xl:w-14" />
-                {accountUUIDs.length !== 0 && (
-                    <div className="absolute right-2 top-2 flex h-fit w-fit rounded-lg bg-red-500/90 p-1">
-                        <div className="h-1 w-1 rounded-full bg-white"></div>
-                    </div>
-                )}
+                {MemberIcon}
+                {accountUUIDs.length !== 0 && <NotificationBadge />}
             </button>
         </>
     );

--- a/front/components/NavigationBar/FriendButton.tsx
+++ b/front/components/NavigationBar/FriendButton.tsx
@@ -24,7 +24,7 @@ export function FriendButton() {
             </Dialog>
             <button
                 onClick={() => setIsOpen(true)}
-                className="relative flex h-fit w-fit"
+                className="relative flex h-fit w-fit rounded outline-none focus-visible:outline-primary/70"
             >
                 <MemberIcon className="h-12 w-12 rounded-lg p-3 shadow-white drop-shadow-[0_0_0.1rem_#ffffff30] hover:bg-primary/30 hover:text-white/80 focus:bg-controlsSelected active:bg-secondary 2xl:h-14 2xl:w-14" />
                 {accountUUIDs.length !== 0 && (

--- a/front/components/NavigationBar/NavigationBar.tsx
+++ b/front/components/NavigationBar/NavigationBar.tsx
@@ -13,11 +13,12 @@ import { usePrivateProfile } from "@/hooks/useProfile";
 export function NavigationBar() {
     return (
         <div className="relative flex h-fit w-full flex-row items-center justify-between bg-primary/30 p-2 backdrop-blur-[20px] backdrop-brightness-100">
-            <Link className="relative" href="/">
+            <Link tabIndex={-1} className="relative" href="/">
                 <DoubleSharp
-                    className="w-12 p-2 text-white hover:drop-shadow-[0_0_0.3rem_#ffffff70]"
-                    width="100%"
-                    height="100%"
+                    tabIndex={0}
+                    className="w-12 rounded-lg p-2 text-white outline-none transition-all hover:drop-shadow-[0_0_0.3rem_#ffffff90] focus-visible:outline-primary/70"
+                    width={48}
+                    height={48}
                 />
             </Link>
             <div className="relative flex flex-row items-center justify-between gap-4">
@@ -42,10 +43,13 @@ function ProfileButton() {
     };
 
     return (
-        <button onClick={asyncRoute}>
+        <button
+            className="flex h-12 w-12 items-center justify-center rounded-lg outline-none hover:bg-primary/30 focus-visible:outline-primary/70 active:bg-secondary/70"
+            onClick={asyncRoute}
+        >
             <Avatar
                 accountUUID={currentAccountUUID}
-                className="relative h-9 w-9 bg-white/30"
+                className="relative h-8 w-8 bg-white/30"
                 privileged={true}
             />
         </button>

--- a/front/components/NavigationBar/NavigationBar.tsx
+++ b/front/components/NavigationBar/NavigationBar.tsx
@@ -36,16 +36,16 @@ function ProfileButton() {
     const router = useRouter();
     const profile = usePrivateProfile();
 
-    const asyncRoute = async () => {
-        //FIXME: 이거 어떻게 해야하나요 프로미스 리턴 해결법..?
-        await new Promise((res) => setTimeout(res, 0));
-        router.push("/profile/" + profile?.nickName + "/" + profile?.nickTag);
+    const gotoMyProfile = () => {
+        if (profile !== undefined) {
+            router.push(`/profile/${profile.nickName}/${profile.nickTag}`);
+        }
     };
 
     return (
         <button
             className="flex h-12 w-12 items-center justify-center rounded-lg outline-none hover:bg-primary/30 focus-visible:outline-primary/70 active:bg-secondary/70"
-            onClick={asyncRoute}
+            onClick={() => gotoMyProfile()}
         >
             <Avatar
                 accountUUID={currentAccountUUID}

--- a/front/components/NavigationBar/NavigationBar.tsx
+++ b/front/components/NavigationBar/NavigationBar.tsx
@@ -1,14 +1,8 @@
-"use client";
-
-import React from "react";
 import Link from "next/link";
-import { Avatar } from "@/components/Avatar";
 import { DoubleSharp } from "@/components/ImageLibrary";
 import { FriendButton } from "./FriendButton";
-import { useCurrentAccountUUID } from "@/hooks/useCurrent";
 import { ChatButton } from "./ChatButton";
-import { useRouter } from "next/navigation";
-import { usePrivateProfile } from "@/hooks/useProfile";
+import { ProfileButton } from "./ProfileButton";
 
 export function NavigationBar() {
     return (
@@ -21,6 +15,7 @@ export function NavigationBar() {
                     height={48}
                 />
             </Link>
+            {/* TODO: matching 대기중이면 중간에 정보 표시? */}
             <div className="relative flex flex-row items-center justify-between gap-4">
                 <ChatButton />
                 <FriendButton />
@@ -28,30 +23,5 @@ export function NavigationBar() {
                 <ProfileButton />
             </div>
         </div>
-    );
-}
-
-function ProfileButton() {
-    const currentAccountUUID = useCurrentAccountUUID();
-    const router = useRouter();
-    const profile = usePrivateProfile();
-
-    const gotoMyProfile = () => {
-        if (profile !== undefined) {
-            router.push(`/profile/${profile.nickName}/${profile.nickTag}`);
-        }
-    };
-
-    return (
-        <button
-            className="flex h-12 w-12 items-center justify-center rounded-lg outline-none hover:bg-primary/30 focus-visible:outline-primary/70 active:bg-secondary/70"
-            onClick={() => gotoMyProfile()}
-        >
-            <Avatar
-                accountUUID={currentAccountUUID}
-                className="relative h-8 w-8 bg-white/30"
-                privileged={true}
-            />
-        </button>
     );
 }

--- a/front/components/NavigationBar/NotificationBadge.tsx
+++ b/front/components/NavigationBar/NotificationBadge.tsx
@@ -1,0 +1,7 @@
+export function NotificationBadge() {
+    return (
+        <div className="absolute right-2 top-2 flex h-fit w-fit rounded-lg bg-red-500/90 p-1">
+            <div className="h-1 w-1 rounded-full bg-white"></div>
+        </div>
+    );
+}

--- a/front/components/NavigationBar/ProfileButton.tsx
+++ b/front/components/NavigationBar/ProfileButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Avatar } from "@/components/Avatar";
+import { useCurrentAccountUUID } from "@/hooks/useCurrent";
+import { useRouter } from "next/navigation";
+import { usePrivateProfile } from "@/hooks/useProfile";
+
+export function ProfileButton() {
+    const currentAccountUUID = useCurrentAccountUUID();
+    const router = useRouter();
+    const profile = usePrivateProfile();
+
+    const gotoMyProfile = () => {
+        if (profile !== undefined) {
+            router.push(`/profile/${profile.nickName}/${profile.nickTag}`);
+        }
+    };
+
+    return (
+        <button
+            className="flex h-12 w-12 items-center justify-center rounded-lg outline-none hover:bg-primary/30 focus-visible:outline-primary/70 active:bg-secondary/70"
+            onClick={() => gotoMyProfile()}
+        >
+            <Avatar
+                accountUUID={currentAccountUUID}
+                className="relative h-8 w-8 bg-white/30"
+                privileged={true}
+            />
+        </button>
+    );
+}

--- a/front/components/Profile/EditPanel.tsx
+++ b/front/components/Profile/EditPanel.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 import { Panel } from "./Panel";
 import { Avatar } from "../Avatar";
-import { Seperator } from "./GameHistoryPanel";
+import { Separator } from "./GameHistoryPanel";
 import { usePublicProfile } from "@/hooks/useProfile";
 import { useCurrentAccountUUID } from "@/hooks/useCurrent";
 
@@ -23,7 +23,7 @@ export function EditPanel() {
                             privileged={false}
                         />
                     </EditPanelItemHeaderTitle>
-                    <Seperator />
+                    <Separator />
                     <EditPanelItemHeaderContent>
                         <div className="flex flex-col">
                             <span>{profile?.nickName}</span>

--- a/front/components/Profile/GameHistoryPanel.tsx
+++ b/front/components/Profile/GameHistoryPanel.tsx
@@ -481,20 +481,20 @@ function StatRating({ history }: { history: GameHistory }) {
 function ItemWrapper({
     children,
     className,
-    seperatorDir = "left",
+    separatorDir = "left",
 }: React.PropsWithChildren<{
     className: string;
-    seperatorDir?: "left" | "right" | "none";
+    separatorDir?: "left" | "right" | "none";
 }>) {
     return (
         <>
-            {seperatorDir === "left" && <Seperator className={className} />}
+            {separatorDir === "left" && <Separator className={className} />}
             <div
                 className={`${className} mx-1 h-full w-20 shrink-0 flex-col items-center justify-center py-4`}
             >
                 {children}
             </div>
-            {seperatorDir === "right" && <Seperator className={className} />}
+            {separatorDir === "right" && <Separator className={className} />}
         </>
     );
 }
@@ -512,7 +512,7 @@ function GameHistoryDetail({ history }: { history: GameHistory }) {
                 <div className="flex h-full w-full flex-row justify-around">
                     <ProfileBlockInGame team={history.ally} />
 
-                    <Seperator className="flex" />
+                    <Separator className="flex" />
 
                     <ProfileBlockInGame team={history.enemy} />
                 </div>
@@ -531,20 +531,20 @@ function GameHistoryDetail({ history }: { history: GameHistory }) {
                     </span>
                 </div>
 
-                <ItemWrapper seperatorDir="right" className="flex @md:hidden">
+                <ItemWrapper separatorDir="right" className="flex @md:hidden">
                     <span className="relative flex text-sm font-semibold italic">
                         {history.statistics.playTime}
                     </span>
                 </ItemWrapper>
 
-                <ItemWrapper seperatorDir="right" className={"flex @lg:hidden"}>
+                <ItemWrapper separatorDir="right" className={"flex @lg:hidden"}>
                     <span className="relative flex text-sm font-semibold italic">
                         {history.statistics.startTimeStamp}
                     </span>
                 </ItemWrapper>
 
                 <ItemWrapper
-                    seperatorDir="right"
+                    separatorDir="right"
                     className="hidden @md:flex @2xl:hidden"
                 >
                     <span className="relative flex shrink-0 text-sm font-semibold italic">
@@ -601,13 +601,13 @@ function SetScore({ setData }: { setData: SetData }) {
                         {setData.ally}
                     </span>
                 </div>
-                <Seperator />
+                <Separator />
                 <div className="flex items-center justify-center px-4 py-2">
                     <span className="rounded p-1 pr-1.5 text-xl font-extrabold italic">
                         {setData.enemy}
                     </span>
                 </div>
-                <Seperator />
+                <Separator />
                 <div className="flex flex-col items-center justify-center p-3">
                     <span className="rounded p-1 pr-1.5 font-extrabold italic text-tertiary/80">
                         MVP
@@ -640,7 +640,7 @@ function ProfileItemMinimal({ accountUUID }: { accountUUID: AccountUUID }) {
     );
 }
 
-export function Seperator({ className }: { className?: string | undefined }) {
+export function Separator({ className }: { className?: string | undefined }) {
     return (
         <div className={`${className} min-w-min py-4`}>
             <div className="h-full w-[1px] bg-black/30"> </div>

--- a/front/components/Profile/ProfileSection.tsx
+++ b/front/components/Profile/ProfileSection.tsx
@@ -1,4 +1,4 @@
-import { editPanelVisibilityAtom } from "@/atom/ProfileAtom";
+import { EditPanelVisibilityAtom } from "@/atom/ProfileAtom";
 import { Avatar } from "@/components/Avatar";
 import { DoubleSharp, Icon } from "@/components/ImageLibrary";
 import { useCurrentAccountUUID } from "@/hooks/useCurrent";
@@ -22,14 +22,14 @@ export function ProfileSection({ accountUUID }: { accountUUID: string }) {
     return (
         <div className="h-20 w-full shrink-0 bg-windowGlass/30 p-4 lg:h-full lg:w-28">
             <div className="flex w-full flex-row items-center justify-between gap-4 lg:flex-col">
-                <Link href={"/"}>
+                <Link href="/">
                     <DoubleSharp className="h-8 w-8 shadow-white hover:drop-shadow-[0_0_0.3rem_#ffffff70] " />
                 </Link>
                 <div className="flex h-full w-full flex-row justify-start gap-4 lg:flex-col">
                     <Avatar
                         accountUUID={accountUUID}
                         className="relative h-12 w-12 bg-white/30 lg:h-20 lg:w-20"
-                        privileged={relationship === "stranger" ? false : true}
+                        privileged={relationship !== "stranger"}
                     />
                     <div className="flex w-full flex-col items-start justify-center text-base md:text-lg lg:text-xl">
                         <h1>{profile?.nickName}</h1>
@@ -45,7 +45,7 @@ export function ProfileSection({ accountUUID }: { accountUUID: string }) {
 }
 
 function RelationshipButton({ relationship }: { relationship: Relationship }) {
-    const showEditPanel = useSetAtom(editPanelVisibilityAtom);
+    const showEditPanel = useSetAtom(EditPanelVisibilityAtom);
 
     switch (relationship) {
         case "myself":

--- a/front/hooks/useChatRoom.ts
+++ b/front/hooks/useChatRoom.ts
@@ -5,6 +5,7 @@ import { useSWRConfig } from "swr";
 import { ChatRoomListAtom } from "@/atom/ChatAtom";
 import { GlobalStore } from "@/atom/GlobalStore";
 import { useAtomCallback } from "jotai/utils";
+import { NULL_UUID } from "@/library/akasha-lib";
 
 export function useChatRoomTitle(roomUUID: string) {
     const callback = useCallback(
@@ -41,10 +42,8 @@ export function useChatRoomTotalUnreadCount() {
         useCallback(async (get, _set) => {
             const roomList = get(ChatRoomListAtom);
             const promises = roomList.map((room) => {
-                const lastMessageId = room.lastMessageId ?? "";
-                if (lastMessageId !== "")
-                    return ChatStore.countAfterMessage(room.id, lastMessageId);
-                else return Promise.resolve(0);
+                const lastMessageId = room.lastMessageId ?? NULL_UUID;
+                return ChatStore.countAfterMessage(room.id, lastMessageId);
             });
 
             const unReadCounts = await Promise.all(promises);
@@ -66,13 +65,11 @@ export function useChatRoomUnreadCount(roomUUID: string) {
                 const roomList = get(ChatRoomListAtom);
                 const lastReadMessageUUID =
                     roomList.find((e) => e.id === roomUUID)?.lastMessageId ??
-                    "";
-                return lastReadMessageUUID !== ""
-                    ? await ChatStore.countAfterMessage(
-                          roomUUID,
-                          lastReadMessageUUID,
-                      )
-                    : 0;
+                    NULL_UUID;
+                return await ChatStore.countAfterMessage(
+                    roomUUID,
+                    lastReadMessageUUID,
+                );
             },
             [],
         ),

--- a/front/hooks/useChatRoom.ts
+++ b/front/hooks/useChatRoom.ts
@@ -46,11 +46,12 @@ export function useChatRoomTotalUnreadCount() {
                 return ChatStore.countAfterMessage(room.id, lastMessageId);
             });
 
-            const unReadCounts = await Promise.all(promises);
-            return unReadCounts.reduce(
+            const unreadCounts = await Promise.all(promises);
+            const totalUnreadCount = unreadCounts.reduce(
                 (accumulator, currentValue) => accumulator + currentValue,
                 0,
             );
+            return totalUnreadCount;
         }, []),
         { store: GlobalStore },
     );

--- a/front/hooks/useChatRoom.ts
+++ b/front/hooks/useChatRoom.ts
@@ -36,6 +36,29 @@ export function useChatRoomLatestMessage(roomUUID: string) {
     return data;
 }
 
+export function useChatRoomTotalUnreadCount() {
+    const callback = useAtomCallback(
+        useCallback(async (get, _set) => {
+            const roomList = get(ChatRoomListAtom);
+            const promises = roomList.map((room) => {
+                const lastMessageId = room.lastMessageId ?? "";
+                if (lastMessageId !== "")
+                    return ChatStore.countAfterMessage(room.id, lastMessageId);
+                else return Promise.resolve(0);
+            });
+
+            const unReadCounts = await Promise.all(promises);
+            return unReadCounts.reduce(
+                (accumulator, currentValue) => accumulator + currentValue,
+                0,
+            );
+        }, []),
+        { store: GlobalStore },
+    );
+    const { data } = useSWR(["ChatStore", "TotalUnreadCount"], callback);
+    return data;
+}
+
 export function useChatRoomUnreadCount(roomUUID: string) {
     const callback = useAtomCallback(
         useCallback(


### PR DESCRIPTION
보류: 라벨과 연계된 인풋을 키보드로 선택하는 것.. 잘 안되네요.

토글 버튼 중, 사이드바 내부 페이지가 변경되는 방만들기, 차단목록 등은 scale-105를 적용해서 약간 커지게 만들고 애니메이션도 추가했습니다.

room block도 아웃라인을 primary color로 통일시켰습니다. 